### PR TITLE
feat: persist submission timestamp

### DIFF
--- a/dialogsquestionsxblock/dialogsquestionsxblock.py
+++ b/dialogsquestionsxblock/dialogsquestionsxblock.py
@@ -5,6 +5,7 @@ from django.template import Context, Template
 
 from xblock.core import XBlock
 from xblock.fields import Integer, Scope, String, Boolean, Dict, Float
+from xmodule.fields import Date
 from xblock.fragment import Fragment
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 import datetime
@@ -171,6 +172,11 @@ class DialogsQuestionsXBlock(StudioEditableXBlockMixin, XBlock):
         scope=Scope.user_state,
     )
 
+    last_submission_time = Date(
+        help= "Fecha del último envío",
+        scope=Scope.user_state
+    )
+
     has_score = True
 
     icon_class = "problem"
@@ -324,6 +330,8 @@ class DialogsQuestionsXBlock(StudioEditableXBlockMixin, XBlock):
                 pass
         else:
             errores = True
+
+        self.last_submission_time = datetime.datetime.now(utc)
         #return to show score
         return {
                 'max_attempts': self.max_attempts,
@@ -332,7 +340,8 @@ class DialogsQuestionsXBlock(StudioEditableXBlockMixin, XBlock):
                 'indicator_class': self.get_indicator_class(), 
                 'show_correctness' : self.get_show_correctness(),
                 'show_answer': self.show_answer,
-                'errores': errores
+                'errores': errores,
+                'last_submission_time': self.last_submission_time.isoformat()
             }
 
     @XBlock.json_handler

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def package_data(pkg, roots):
 
 setup(
     name='dialogsquestionsxblock-xblock',
-    version='1.0.0',
+    version='1.1.0',
     description='dialogsquestionsxblock XBlock', 
     license='AGPL v3',
     packages=[


### PR DESCRIPTION
Agrega el campo last_submission_time en user_state para guardar la fecha y hora de cada envío.

Cherry pick de https://github.com/eol-uchile/eol-dialogs-question-xblock/pull/4/changes/85473a15b860979262e46120a368254742a45f2b.

Resuelve https://github.com/eol-uchile/eol-dialogs-question-xblock/issues/17 y permite cerrar https://github.com/eol-uchile/eol-dialogs-question-xblock/pull/4